### PR TITLE
use AbsoluteReportHTMLURL to handle relative report url from IQ 104+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.0
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10
 	github.com/sonatype-nexus-community/nancy v1.0.1
 	github.com/spf13/afero v1.3.4
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,9 @@ require (
 	github.com/package-url/packageurl-go v0.1.0
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.9
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3
 	github.com/sonatype-nexus-community/nancy v1.0.1
 	github.com/spf13/afero v1.3.4
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatype-nexus-community/go-sona-types v0.0.8 h1:6xb9BIC2w3y4kF/xQA25Zs6Yrl8ZqFkfH77AKPaG4RA=
 github.com/sonatype-nexus-community/go-sona-types v0.0.8/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
-github.com/sonatype-nexus-community/go-sona-types v0.0.9 h1:3YeHMJhX/bupheORvwtDD0EF7peaN26qCsZhloMPCFI=
-github.com/sonatype-nexus-community/go-sona-types v0.0.9/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3 h1:UaN4whlAsVLMq9hIgENZvb2RXzsWBkSUflFYq8uctNE=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/sonatype-nexus-community/nancy v1.0.1 h1:d+mf5iiFgNG3WcapXkOLWBS2YA69Gw7lTn+f1S+FLsI=
 github.com/sonatype-nexus-community/nancy v1.0.1/go.mod h1:3uqqbvpP2pIyaZqCY17HOmLMMV2ATDD//tVrhqI+XZg=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatype-nexus-community/go-sona-types v0.0.8 h1:6xb9BIC2w3y4kF/xQA25Zs6Yrl8ZqFkfH77AKPaG4RA=
 github.com/sonatype-nexus-community/go-sona-types v0.0.8/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3 h1:UaN4whlAsVLMq9hIgENZvb2RXzsWBkSUflFYq8uctNE=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10 h1:VW+OE1vAjBwwRCz7jz4xcBbUn1j3bz1gFnEw1YYmYGs=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/sonatype-nexus-community/nancy v1.0.1 h1:d+mf5iiFgNG3WcapXkOLWBS2YA69Gw7lTn+f1S+FLsI=
 github.com/sonatype-nexus-community/nancy v1.0.1/go.mod h1:3uqqbvpP2pIyaZqCY17HOmLMMV2ATDD//tVrhqI+XZg=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -166,6 +167,24 @@ func sendBomToIQ(config config.Config, binaryName string, sbom string) {
 		logger.GetLogger().WithField("err", iqerr).Error("error submitting bom")
 	}
 	logger.GetLogger().WithField("result", result).Info("Completed submission of bom to IQ")
+
+	// print summary
+	showPolicyActionMessage(result, os.Stdout)
+}
+
+func showPolicyActionMessage(res iq.StatusURLResult, writer io.Writer) {
+	_, _ = fmt.Fprintln(writer)
+	switch res.PolicyAction {
+	case iq.PolicyActionFailure:
+		_, _ = fmt.Fprintln(writer, "How ya doin? You have some policy violations to clean up!")
+		_, _ = fmt.Fprintln(writer, "Report URL: ", res.AbsoluteReportHTMLURL)
+	case iq.PolicyActionWarning:
+		_, _ = fmt.Fprintln(writer, "Howz it goin? There are policy warnings to investigate!")
+		_, _ = fmt.Fprintln(writer, "Report URL: ", res.AbsoluteReportHTMLURL)
+	default:
+		_, _ = fmt.Fprintln(writer, "Wonderbar! No policy violations reported for this audit!")
+		_, _ = fmt.Fprintln(writer, "Report URL: ", res.AbsoluteReportHTMLURL)
+	}
 }
 
 func generateConanFiles(myConfig config.Config, results *linker.Results) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/sonatype-nexus-community/go-sona-types/iq"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func Test_showPolicyActionMessage(t *testing.T) {
+	verifyReportURL(t, "anythingElse") //default policy action
+	verifyReportURL(t, iq.PolicyActionWarning)
+	verifyReportURL(t, iq.PolicyActionFailure)
+}
+
+func verifyReportURL(t *testing.T, policyAction string) {
+	var buf bytes.Buffer
+	bufWriter := bufio.NewWriter(&buf)
+	theURL := "someURL"
+	showPolicyActionMessage(iq.StatusURLResult{AbsoluteReportHTMLURL: theURL, PolicyAction: policyAction}, bufWriter)
+	bufWriter.Flush()
+	assert.True(t, strings.Contains(buf.String(), "Report URL:  "+theURL), buf.String())
+}


### PR DESCRIPTION
Newer versions of IQ send a relative report URL. This PR uses the latest version of `go-sona-types` library, which will ensure an absolute report url is populated.

While I was in there, I also added a print out of the ReportURL.

TODO: Update to use a released version of go-sona-types when possible.